### PR TITLE
increase bindgen version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xenvmevent-sys"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Mathieu Tarral <mathieu.tarral@protonmail.com>"]
 edition = "2018"
 readme = "README.md"
@@ -11,4 +11,4 @@ license = "GPL-3.0-only"
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.52.0"
+bindgen = "0.69.4"


### PR DESCRIPTION
When trying to generate bindings, I realized that bindgen.rs was struggling with the version of xen I am using (xen 4.18.1pre-1).

Updating bindgen to "0.69.4" fixes the issue.
Bumped the crate version to reflect the changes.
